### PR TITLE
Fix sidebar text and scrolling behavior

### DIFF
--- a/src/components/FilterBar.vue
+++ b/src/components/FilterBar.vue
@@ -53,6 +53,12 @@ export default Vue.extend({
     padding-left: 15px;
     padding-top: 3vmin;
     width: 100%;
+
+    p {
+      font-weight: 600;
+      margin-bottom: 0;
+      margin-right: 12px;
+    }
   }
   
   .filter-checkboxes {
@@ -62,11 +68,5 @@ export default Vue.extend({
   .filter-checkboxes .custom-control-inline {
     display: inline;
     white-space: nowrap;
-  }
-
-  p {
-    font-weight: 600;
-    margin-bottom: 0;
-    margin-right: 12px;
   }
 </style>

--- a/src/views/LabExplore.vue
+++ b/src/views/LabExplore.vue
@@ -385,13 +385,13 @@ export default Vue.extend({
     height: calc(64vh - 15px);
 }
 
-.left-block {
+.left-block {  
     overflow: overlay;
+    overflow-wrap: break-word;
     max-height: 100%;
-
     position: relative;
     display: flex;
-    flex: 0 0 30vw;
+    flex: 0 0 40vw;
     padding-right: 25px;
     padding-left: 50px;
 
@@ -404,7 +404,7 @@ export default Vue.extend({
         margin: auto;
 
         p {
-            font-size: 1.8vw;
+            font-size: 1.7vw;
         }
         strong {
             font-size: larger;


### PR DESCRIPTION
When the sidebar description contains sequence strings, it didn't wrap appropriately. overflow-wrap and overflow: auto address that behavior. Closes #25 and #27. 