### PR TITLE
Fix/launch puzzle

### DIFF
--- a/src/components/FilterBar.vue
+++ b/src/components/FilterBar.vue
@@ -53,6 +53,12 @@ export default Vue.extend({
     padding-left: 15px;
     padding-top: 3vmin;
     width: 100%;
+
+    p {
+      font-weight: 600;
+      margin-bottom: 0;
+      margin-right: 12px;
+    }
   }
   
   .filter-checkboxes {
@@ -62,11 +68,5 @@ export default Vue.extend({
   .filter-checkboxes .custom-control-inline {
     display: inline;
     white-space: nowrap;
-  }
-
-  p {
-    font-weight: 600;
-    margin-bottom: 0;
-    margin-right: 12px;
   }
 </style>

--- a/src/components/PuzzleCard.vue
+++ b/src/components/PuzzleCard.vue
@@ -103,7 +103,7 @@ export default Vue.component('puzzle-card', {
     methods: {
         goToPuzzle: function() {
             if(!this.playable) {
-                this.$router.push(`${this.$router.currentRoute.fullPath}/${this.id}`);
+                this.$router.push(`${this.$router.currentRoute.path}/${this.id}`);
             }
         }
     }

--- a/src/views/LabExplore.vue
+++ b/src/views/LabExplore.vue
@@ -385,13 +385,13 @@ export default Vue.extend({
     height: calc(64vh - 15px);
 }
 
-.left-block {
+.left-block {  
     overflow: overlay;
+    overflow-wrap: break-word;
     max-height: 100%;
-
     position: relative;
     display: flex;
-    flex: 0 0 30vw;
+    flex: 0 0 40vw;
     padding-right: 25px;
     padding-left: 50px;
 
@@ -404,7 +404,7 @@ export default Vue.extend({
         margin: auto;
 
         p {
-            font-size: 1.8vw;
+            font-size: 1.7vw;
         }
         strong {
             font-size: larger;

--- a/src/views/LabExplore.vue
+++ b/src/views/LabExplore.vue
@@ -386,6 +386,7 @@ export default Vue.extend({
 }
 
 .left-block {  
+    overflow: auto;
     overflow: overlay;
     overflow-wrap: break-word;
     max-height: 100%;


### PR DESCRIPTION
Closes #33. The `PuzzleCard` component used `this.$router.currentRoute.fullPath` which includes the query string. Using `this.$router.currentRoute.path` fixes this bug, allowing puzzles to be launched even when filters are active.

This component is also used in too many contexts (Puzzle Explore and Single Puzzle View) with varying behavior and visuals, and uses custom events in some contexts and direct imperative functions in others. Will need clean up in mobile re-write. 