### PR TITLE
Fix bug where active filters in explore would prevent game launch

### DIFF
--- a/src/components/PuzzleCard.vue
+++ b/src/components/PuzzleCard.vue
@@ -103,7 +103,7 @@ export default Vue.component('puzzle-card', {
     methods: {
         goToPuzzle: function() {
             if(!this.playable) {
-                this.$router.push(`${this.$router.currentRoute.fullPath}/${this.id}`);
+                this.$router.push(`${this.$router.currentRoute.path}/${this.id}`);
             }
         }
     }


### PR DESCRIPTION
Closes https://github.com/eternagame/eterna-mobile/issues/33. The PuzzleCard component used this.$router.currentRoute.fullPath which includes the query string. Using this.$router.currentRoute.path fixes this bug, allowing puzzles to be launched even when filters are active.

This component is also used in too many contexts (Puzzle Explore and Single Puzzle View) with varying behavior and visuals, and uses custom events in some contexts and direct imperative functions in others. Will need clean up in mobile re-write.