### PR TITLE
Implement back button for lab view and puzzle view

### DIFF
--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -72,16 +72,16 @@ export default Vue.component('puzzle-view-progress-bar', {
     },
     methods:{
         goToPuzzles(){
-            this.$router.replace('/puzzles');
+            this.$router.push('/puzzles');
         },
         goToLabs() {
-            this.$router.replace('/labs');
+            this.$router.push('/labs');
         },
         goToHome() {
-            this.$router.replace('/home');
+            this.$router.push('/home');
         },
         goToQuests() {
-            this.$router.replace('/quests');
+            this.$router.push('/quests');
         },
     }
 })

--- a/src/views/LabView.vue
+++ b/src/views/LabView.vue
@@ -110,9 +110,13 @@
         <b-row id="puzzle-view-footer">
             <b-col>
                 <b-row style="justify-content:flex-start;align-items:flex-start;">
-                    <router-link to="/about">
-                        <div class="puzzle-view-about-button" />
-                    </router-link>
+                    <button @click="$router.go(-1)" class="back-button">
+                        <svg viewBox="0 0 24 24" class="feather feather-arrow-left-circle">
+                            <circle cx="12" cy="12" r="10"></circle>
+                            <polyline points="12 8 8 12 12 16"></polyline>
+                            <line x1="16" y1="12" x2="8" y2="12"></line>
+                        </svg>
+                    </button>
                 </b-row>
             </b-col>
             <b-col class="col-8" style="padding:0">
@@ -225,13 +229,13 @@ export default Vue.extend({
             return Math.max(min, Math.min(max, x));
         },
         play(id: number) {
-            this.$router.replace(`/game/${id}`);
+            this.$router.push(`/game/${id}`);
         },
         review(id: number) {
-            this.$router.replace(`/game/browse/${id}`);
+            this.$router.push(`/game/browse/${id}`);
         },
         details(id: number) {
-            this.$router.replace(`/puzzles/${id}`);
+            this.$router.push(`/puzzles/${id}`);
         },
         openChat() {
             if (this.chat) {
@@ -539,5 +543,20 @@ export default Vue.extend({
 }
 .hidden{
   opacity: 0;
+}
+
+.back-button {
+    background-color: transparent;
+    border: none;
+
+    svg {
+        width: 6vmin;
+        height: 6vmin;
+        fill: none;
+        stroke: white;
+        stroke-width: 2;
+        stroke-linecap: round;
+        stroke-linejoin: round;
+    }
 }
 </style>

--- a/src/views/PuzzleExplore.vue
+++ b/src/views/PuzzleExplore.vue
@@ -175,7 +175,7 @@ export default Vue.extend({
             return Math.max(min, Math.min(max, x));
         },
         play(id: number) {
-            this.$router.replace(`game/${id}`);
+            this.$router.push(`game/${id}`);
         },
         openChat() {
             if (this.chat) {

--- a/src/views/PuzzleView.vue
+++ b/src/views/PuzzleView.vue
@@ -70,9 +70,13 @@
         <b-row id="puzzle-view-footer">
             <b-col>
                 <b-row style="justify-content:flex-start;align-items:flex-start;">
-                    <router-link to="/about">
-                        <div class="puzzle-view-about-button" />
-                    </router-link>
+                    <button @click="$router.go(-1)" class="back-button">
+                        <svg viewBox="0 0 24 24" class="feather feather-arrow-left-circle">
+                            <circle cx="12" cy="12" r="10"></circle>
+                            <polyline points="12 8 8 12 12 16"></polyline>
+                            <line x1="16" y1="12" x2="8" y2="12"></line>
+                        </svg>
+                    </button>
                 </b-row>
             </b-col>
             <b-col class="col-8" style="padding:0" v-if="true">
@@ -152,7 +156,7 @@ export default Vue.extend({
             );
         },
         play(id: number) {
-            this.$router.replace(`/game/${id}`);
+            this.$router.push(`/game/${id}`);
         },
         openChat() {
             if (this.chat) {
@@ -398,5 +402,20 @@ export default Vue.extend({
 }
 .hidden{
   opacity: 0;
+}
+
+.back-button {
+    background-color: transparent;
+    border: none;
+
+    svg {
+        width: 6vmin;
+        height: 6vmin;
+        fill: none;
+        stroke: white;
+        stroke-width: 2;
+        stroke-linecap: round;
+        stroke-linejoin: round;
+    }
 }
 </style>


### PR DESCRIPTION
Closes #31. Issue identified when visiting a puzzle view from within a lab. There was no way to go back to the selected lab to look at other puzzles; users had to renavigate through the Labs tab. Only implemented on these deeper views, not on the standard LabExplore and PuzzleExplore views because users can use the standard nav bar there.