### PR TITLE
Add dom-purify to sanitize user-provided descriptions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "cordova-plugin-navigationbar": "^1.0.31",
         "cordova-plugin-splashscreen": "^6.0.0",
         "cordova-plugin-statusbar": "^3.0.0",
+        "dompurify": "^2.3.6",
         "es6-promise-plugin": "^4.2.2",
         "eterna-chat-wrapper": "https://github.com/eternagame/eterna-chat-wrapper/archive/dd47b03753aeae81c3a8450933b274216515d1bc.tar.gz",
         "vue": "^2.6.14",
@@ -31,6 +32,7 @@
       "devDependencies": {
         "@globules-io/cordova-plugin-ios-xhr": "^1.2.1",
         "@npmcli/run-script": "^2.0.0",
+        "@types/dompurify": "^2.3.3",
         "@types/node": "^17.0.18",
         "@types/webpack": "^5.28.0",
         "coffeescript": "^1.12.7",
@@ -420,6 +422,15 @@
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
+    "node_modules/@types/dompurify": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-2.3.3.tgz",
+      "integrity": "sha512-nnVQSgRVuZ/843oAfhA25eRSNzUFcBPk/LOiw5gm8mD9/X7CNcbRkQu/OsjCewO8+VIYfPxUnXvPEVGenw14+w==",
+      "dev": true,
+      "dependencies": {
+        "@types/trusted-types": "*"
+      }
+    },
     "node_modules/@types/eslint": {
       "version": "8.4.1",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.1.tgz",
@@ -474,6 +485,12 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
+      "dev": true
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
+      "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg==",
       "dev": true
     },
     "node_modules/@types/webpack": {
@@ -3229,6 +3246,11 @@
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
+    },
+    "node_modules/dompurify": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.3.6.tgz",
+      "integrity": "sha512-OFP2u/3T1R5CEgWCEONuJ1a5+MFKnOYpkywpUSxv/dj1LeBT1erK+JwM7zK0ROy2BRhqVCf0LRw/kHqKuMkVGg=="
     },
     "node_modules/domutils": {
       "version": "2.8.0",
@@ -9795,6 +9817,15 @@
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
+    "@types/dompurify": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-2.3.3.tgz",
+      "integrity": "sha512-nnVQSgRVuZ/843oAfhA25eRSNzUFcBPk/LOiw5gm8mD9/X7CNcbRkQu/OsjCewO8+VIYfPxUnXvPEVGenw14+w==",
+      "dev": true,
+      "requires": {
+        "@types/trusted-types": "*"
+      }
+    },
     "@types/eslint": {
       "version": "8.4.1",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.1.tgz",
@@ -9849,6 +9880,12 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
+      "dev": true
+    },
+    "@types/trusted-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
+      "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg==",
       "dev": true
     },
     "@types/webpack": {
@@ -11973,6 +12010,11 @@
       "requires": {
         "domelementtype": "^2.2.0"
       }
+    },
+    "dompurify": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.3.6.tgz",
+      "integrity": "sha512-OFP2u/3T1R5CEgWCEONuJ1a5+MFKnOYpkywpUSxv/dj1LeBT1erK+JwM7zK0ROy2BRhqVCf0LRw/kHqKuMkVGg=="
     },
     "domutils": {
       "version": "2.8.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "cordova-plugin-navigationbar": "^1.0.31",
     "cordova-plugin-splashscreen": "^6.0.0",
     "cordova-plugin-statusbar": "^3.0.0",
+    "dompurify": "^2.3.6",
     "es6-promise-plugin": "^4.2.2",
     "eterna-chat-wrapper": "https://github.com/eternagame/eterna-chat-wrapper/archive/dd47b03753aeae81c3a8450933b274216515d1bc.tar.gz",
     "vue": "^2.6.14",
@@ -37,6 +38,7 @@
   "devDependencies": {
     "@globules-io/cordova-plugin-ios-xhr": "^1.2.1",
     "@npmcli/run-script": "^2.0.0",
+    "@types/dompurify": "^2.3.3",
     "@types/node": "^17.0.18",
     "@types/webpack": "^5.28.0",
     "coffeescript": "^1.12.7",

--- a/src/views/LabView.vue
+++ b/src/views/LabView.vue
@@ -25,8 +25,7 @@
         </b-row>
         <div class="content">
             <div class="left-block left-aligned">
-            <div>
-                 <div class="lab-description">
+                <div class="lab-description">
                     <p>
                         <strong>
                         {{lab_title}}
@@ -42,47 +41,46 @@
                             {{ status }}
                         </div>
                     </div>
-                    <div  style="lab-description-body" v-html="descriptiontoShow">
+                    <div class="lab-description-body" v-html="descriptiontoShow">
                     </div>
-                            <div >
-                            <b-button size="lg" v-b-modal.full-description-modal>Read More</b-button>
-                                <b-modal
-                                id="full-description-modal"
-                                ref="modal"
-                                size="xl"
-                                header-border-variant="primary"
-                                hide-header
-                                hide-footer
-                                >
-                                <div class="modal_container">
-                                    <div class="modal_header">
-                                    <b-img  class="img-fluid" :src="getBanner" />
-                                    <div class="modal_title">{{lab_title}}</div>
-                                    </div>
-                                    <div class="modal_body" v-html="full_description"/>
-                                </div>
-                                </b-modal>
-                            <b-button size="lg" v-b-modal.lab-updates-modal v-if="labUpdates">Lab Updates</b-button>
+                    <div class="lab-description-more">
+                        <b-button block v-b-modal.full-description-modal>Read More</b-button>
                             <b-modal
-                                id="lab-updates-modal"
-                                ref="modal"
-                                size="xl"
-                                header-border-variant="primary"
-                                hide-header
-                                hide-footer
-                                >
-                                <div class="readmore-scroll">
-                                    <b-img  class="puzzle-card-image" :src="getBanner" />
-                                    <div style="padding: 2vmin;">
-                                            <div class="modal-title">
-                                                    Lab Updates!
-                                            </div>
-                                            <div  style="font-size: 2vmin;" v-html="labUpdates">
-                                            </div>
-                                    </div>
+                            id="full-description-modal"
+                            ref="modal"
+                            size="xl"
+                            header-border-variant="primary"
+                            hide-header
+                            hide-footer
+                            >
+                            <div class="modal_container">
+                                <div class="modal_header">
+                                <b-img  class="img-fluid" :src="getBanner" />
+                                <div class="modal_title">{{lab_title}}</div>
                                 </div>
-                                </b-modal>
+                                <div class="modal_body" v-html="full_description"/>
                             </div>
+                            </b-modal>
+                        <b-button block v-b-modal.lab-updates-modal v-if="labUpdates">Lab Updates</b-button>
+                        <b-modal
+                            id="lab-updates-modal"
+                            ref="modal"
+                            size="xl"
+                            header-border-variant="primary"
+                            hide-header
+                            hide-footer
+                            >
+                            <div class="readmore-scroll">
+                                <b-img  class="puzzle-card-image" :src="getBanner" />
+                                <div style="padding: 2vmin;">
+                                        <div class="modal-title">
+                                                Lab Updates!
+                                        </div>
+                                        <div  style="font-size: 2vmin;" v-html="labUpdates">
+                                        </div>
+                                </div>
+                            </div>
+                        </b-modal>
                     </div>
             </div>
         </div>
@@ -372,6 +370,17 @@ export default Vue.extend({
 .lab-description{
     position: relative;
     top: -1vmin;
+    overflow: hidden !important;
+
+    &::after {
+        // Horrible hack to add fade-out to bottom of description
+        content: "";
+        width: 100%;
+        height: 80px;
+        position: absolute;
+        bottom: 0px;
+        background-image: linear-gradient(to bottom, transparent, #032a4f 50%);
+    }
 
     p {
         strong {
@@ -382,7 +391,6 @@ export default Vue.extend({
     }
 }
 .lab-description-body {
-    font-size: 0.75rem;
     font-style: normal;
     font-weight: 400;
     margin-bottom: 2vmin;
@@ -564,5 +572,12 @@ export default Vue.extend({
         stroke-linecap: round;
         stroke-linejoin: round;
     }
+}
+
+.lab-description-more {
+    width: 100%;
+    position: absolute;
+    bottom: 0;
+    z-index: 5;
 }
 </style>

--- a/src/views/LabView.vue
+++ b/src/views/LabView.vue
@@ -41,7 +41,7 @@
                             {{ status }}
                         </div>
                     </div>
-                    <div class="lab-description-body" v-html="descriptiontoShow">
+                    <div class="lab-description-body" v-html="description">
                     </div>
                     <div class="lab-description-more">
                         <b-button block v-b-modal.full-description-modal>Read More</b-button>
@@ -58,7 +58,7 @@
                                 <b-img  class="img-fluid" :src="getBanner" />
                                 <div class="modal_title">{{lab_title}}</div>
                                 </div>
-                                <div class="modal_body" v-html="full_description"/>
+                                <div class="modal_body" v-html="description"/>
                             </div>
                             </b-modal>
                         <b-button block v-b-modal.lab-updates-modal v-if="labUpdates">Lab Updates</b-button>
@@ -187,10 +187,7 @@ export default Vue.extend({
         lab_title(): string{
             return this.$store.state.current_lab.lab.title;
         },
-        descriptiontoShow(): string{
-            return DOMPurify.sanitize(this.$store.state.current_lab.lab.body)
-        },
-        full_description(): string{
+        description(): string{
             return DOMPurify.sanitize(this.$store.state.current_lab.lab.body);
         },
         puzzles(): PuzzleData[] {

--- a/src/views/LabView.vue
+++ b/src/views/LabView.vue
@@ -134,6 +134,7 @@
 
 <script lang="ts">
 import Vue from 'vue'
+ import DOMPurify from 'dompurify';
 import ProgressBar from '../components/ProgressBar.vue'
 import PuzzleCard from '../components/TutorialCard.vue'
 import LabPuzzleCard from '../components/LabPuzzleCard.vue'
@@ -142,8 +143,6 @@ import Modal from '../components/Modal.vue'
 import { Action, Achievement, PuzzleData } from '../store';
 
 import ChatManager from '../ChatManager';
-
-const MAX_CHARS = 450;
 
 export default Vue.extend({
     data() {
@@ -191,11 +190,10 @@ export default Vue.extend({
             return this.$store.state.current_lab.lab.title;
         },
         descriptiontoShow(): string{
-            // strip all html, only take the first MAX_CHARS characters and add ending ... tag
-            return this.$store.state.current_lab.lab.body.replace(/<[^>]+>/ig,"").substr(0, MAX_CHARS) + ". . .";
+            return DOMPurify.sanitize(this.$store.state.current_lab.lab.body)
         },
         full_description(): string{
-            return this.$store.state.current_lab.lab.body;
+            return DOMPurify.sanitize(this.$store.state.current_lab.lab.body);
         },
         puzzles(): PuzzleData[] {
             // loop through all rounds? or get first index

--- a/src/views/PuzzleView.vue
+++ b/src/views/PuzzleView.vue
@@ -26,7 +26,7 @@
         <div class="content">
             <div class="left-block left-aligned">
                 <div>
-                    <p><strong>{{title}}</strong></p>
+                    <p><strong>{{puzzle.title}}</strong></p>
                     <p v-html="description"></p>
                 </div>
             </div>
@@ -129,9 +129,6 @@ export default Vue.extend({
         },
         roadmap(): Achievement[] {
             return this.$store.state.roadmap;
-        },
-        title(): string{
-            return DOMPurify.sanitize(this.puzzle.title);
         },
         description(): string{
             return DOMPurify.sanitize(this.puzzle.body);

--- a/src/views/PuzzleView.vue
+++ b/src/views/PuzzleView.vue
@@ -26,8 +26,8 @@
         <div class="content">
             <div class="left-block left-aligned">
                 <div>
-                    <p><strong>{{puzzle.title}}</strong></p>
-                    <p class="puzzle-description-body">{{puzzle.body}}</p>
+                    <p><strong>{{title}}</strong></p>
+                    <p v-html="description"></p>
                 </div>
             </div>
             <b-container id="puzzle-scroll">
@@ -94,6 +94,7 @@
 </template>
 <script lang="ts">
 import Vue from 'vue';
+import DOMPurify from 'dompurify';
 import PuzzleCard from '../components/PuzzleCard.vue';
 import NavBar from '../components/NavBar.vue'
 import { Achievement, Action, Puzzle } from '../store';
@@ -128,6 +129,12 @@ export default Vue.extend({
         },
         roadmap(): Achievement[] {
             return this.$store.state.roadmap;
+        },
+        title(): string{
+            return DOMPurify.sanitize(this.puzzle.title);
+        },
+        description(): string{
+            return DOMPurify.sanitize(this.puzzle.body);
         }
     },
     methods: {


### PR DESCRIPTION
Closes #48. The descriptions are sanitized with dom-purify. I added some styling to the lab description sidebar to make the Read More button more useful (prior implementation stuck it at the end of an arbitrarily truncated string, which Jonathan pointed out could lead to broken HTML after sanitization). Happy to talk about other approaches to this in the rewrite.