### PR TITLE
Hide chat icon on Account and Settings pages

### DIFF
--- a/src/views/Profile.vue
+++ b/src/views/Profile.vue
@@ -47,6 +47,7 @@
           </svg>
         </button>
       </template>
+      <template v-slot:right><div></div></template>
     </NavBar>
   </section>
 </template>

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -53,6 +53,7 @@
           </svg>
         </button>
       </template>
+      <template v-slot:right><div></div></template>
     </NavBar>
     <div class="loading-container" v-if="isLoading">
         <b-spinner class="loading-spinner" />


### PR DESCRIPTION
This is a quick fix to remove the chat icon on the Account and Settings pages. For some reason, Vue doesn't have a way to explicitly prevent default content being shown in a slot; you have to pass some element in to replace the default content, even if it's an empty div with no semantic meaning.

A better approach might be to change the NavBar component to only display the default slot content given a boolean prop, but the NavBar component has outstanding changes with the Quest implementation, and I wanted to avoid merge conflicts. 