### PR TITLE
Hide full nav if the user hasn't completed the tutorial

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -193,6 +193,7 @@ export interface LabData {
       picture: string,
       points: string
       rank: number,
+      lab_access: boolean,
       synthesized_count: number,
       mail_notification: boolean,
       news_notification: boolean,
@@ -393,6 +394,7 @@ export default function createStore(http: AxiosInstance) {
                         picture: user.picture,
                         points: user.points,
                         rank: user.rank,
+                        lab_access: user.is_lab_member,
                         synthesized_count: user.synthesized_count,
                         mail_notification: mail_notification,
                         news_notification: news_notification,

--- a/src/views/Profile.vue
+++ b/src/views/Profile.vue
@@ -47,6 +47,13 @@
           </svg>
         </button>
       </template>
+      <template v-if="!lab_access" v-slot:center>
+        <b-button variant="primary" size="lg" class="nav-button" id="home-btn" @click="$router.push('/')">
+          <div class="home-disabled"></div>
+          Home
+        </b-button>
+      </template>
+      <template v-slot:right><div></div></template>
     </NavBar>
   </section>
 </template>
@@ -83,6 +90,9 @@ export default Vue.extend({
       achievements() {
         return this.$store.state.user ? Object.values(this.$store.state.user.achievements) : [];
       },
+      lab_access() {
+        return this.$store.state.user.lab_access;
+      }
     },
     methods: {
       resolveUrl(path: string) {

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -53,6 +53,13 @@
           </svg>
         </button>
       </template>
+      <template v-if="!lab_access" v-slot:center>
+        <b-button variant="primary" size="lg" class="nav-button" id="home-btn" @click="$router.push('/')">
+          <div class="home-disabled"></div>
+          Home
+        </b-button>
+      </template>
+      <template v-slot:right><div></div></template>
     </NavBar>
     <div class="loading-container" v-if="isLoading">
         <b-spinner class="loading-spinner" />
@@ -100,6 +107,9 @@ export default Vue.extend({
     },
     formValid(): boolean {
       return this.emailValid && this.passwordValid;
+    },
+    lab_access() {
+      return this.$store.state.user.lab_access;
     }
   },
   methods: {


### PR DESCRIPTION
Closes #73. If the user is logged in, and views the Account or Settings pages before they've completed the tutorial, the NavBar shouldn't display the Labs or Puzzles button, just the Home button. Again, could be handled at NavBar component rather than in the individual page views, but avoiding merge conflict with NavBar.