### PR TITLE
Add conditional guards to puzzle list render

### DIFF
--- a/src/views/PuzzleExplore.vue
+++ b/src/views/PuzzleExplore.vue
@@ -98,10 +98,14 @@ export default Vue.extend({
         },
         puzzles(): (PuzzleItem & {cleared: boolean})[] {
             const puzzleList = this.$store.state.puzzle_list as PuzzleList;
-            return puzzleList.puzzles.map(puzzle => ({
-                ...puzzle,
-                cleared: puzzleList.cleared.some(cleared => cleared.nid === puzzle.id)
-            }));
+            if (puzzleList) {
+                return puzzleList.puzzles.map(puzzle => ({
+                    ...puzzle,
+                    cleared: puzzleList.cleared ? puzzleList.cleared.some(cleared => cleared.nid === puzzle.id) : false,
+                }));
+            } else {
+                return [];
+            }
         },
         lab_access(): boolean {
             return this.playablePuzzleIndex >= this.roadmap.length;


### PR DESCRIPTION
Closes #75. The real issue is a problem with the ordering of vuex actions and the component rendering, but this at least fixes the symptoms (e.g, rendering locking up if puzzle_list is undefined). 