### PR TITLE
Adjust dropdown styling to match :focus styling to default

### DIFF
--- a/src/components/HeaderBar.vue
+++ b/src/components/HeaderBar.vue
@@ -48,7 +48,7 @@ export default Vue.extend({
 })
 </script>
 
-<style lang="scss">
+<style lang="scss" scoped>
   .app-header {
     height: 18vh;
     width: 100%;
@@ -57,7 +57,7 @@ export default Vue.extend({
     justify-content: space-between;
   }
 
-  .menu-button:focus {
+  ::v-deep .menu-button:focus {
     background-color: transparent;
     color: var(--white);
   }

--- a/src/components/HeaderBar.vue
+++ b/src/components/HeaderBar.vue
@@ -1,8 +1,8 @@
 <template>
-  <header>
+  <header class="app-header">
     <b-img class="header-logo" :src="logoSourcePng" />
     <div v-if="loggedIn" class="account-dropdown">
-      <b-dropdown right variant="link" toggle-class="text-decoration-none puzzle-view-button" menu-class="puzzle-view-button" no-caret>
+      <b-dropdown right variant="link" toggle-class="text-decoration-none puzzle-view-button menu-button" menu-class="puzzle-view-button" no-caret>
         <template #button-content>
             <b style="line-height:6vmin;margin-right:2vmin;vertical-align:bottom;">{{ username }}</b>
             <div class="puzzle-view-icon-people" />
@@ -48,12 +48,17 @@ export default Vue.extend({
 })
 </script>
 
-<style lang="scss" scoped>
-  header {
+<style lang="scss">
+  .app-header {
     height: 18vh;
     width: 100%;
     padding: 3vmin;
     display: flex;
     justify-content: space-between;
+  }
+
+  .menu-button:focus {
+    background-color: transparent;
+    color: var(--white);
   }
 </style>


### PR DESCRIPTION
Closes #76. We can discuss whether or not this is a necessary fix. I can see how the active styling while focused is confusing to some users. If you click the toggle, the dropdown shows, but if you click the toggle again, the dropdown hides but the toggle button still looks actively styled.

When the account menu toggle is focused, it maintains the active styling of the dropdown menu even if the menu is closed. This can be confusing to users, so we adjust the color styling to match the default styling of the button but maintain the focus outline for accessibility. I had to remove the CSS scoping to keep the classnames the same so I could target the button (Vue-Bootstrap adds classes to the component that don't take scoping into account).