### PR TITLE
Hide selection pop-up and highlighting on Game views

### DIFF
--- a/src/views/BrowseView.vue
+++ b/src/views/BrowseView.vue
@@ -35,5 +35,6 @@ export default Vue.extend({
     width: 100vw;
     height: 100vh;
     border: 0;
+    user-select: none;
 }
 </style>

--- a/src/views/Game.vue
+++ b/src/views/Game.vue
@@ -35,5 +35,6 @@ export default Vue.extend({
     width: 100vw;
     height: 100vh;
     border: 0;
+    user-select: none;
 }
 </style>


### PR DESCRIPTION
Closes #49. When a user taps and holds in the game interface, it triggers the native copy selection behavior, which includes highlighting the entire interface. `user-select: none` on the iframe displaying the game should prevent this behavior.